### PR TITLE
Setup access policies for Bridge Exporter

### DIFF
--- a/cf_templates/eb_app.yml
+++ b/cf_templates/eb_app.yml
@@ -129,6 +129,9 @@ Parameters:
   Env:
     Type: String
     Default: param_place_holder
+  RecordIdsBucket:
+    Type: String
+    Default: param_place_holder
   SynapseApiKey:
     Type: String
     Default: param_place_holder
@@ -237,6 +240,66 @@ Resources:
         Type: SQS/HTTP
   AWSS3AppDeployBucket:
     Type: 'AWS::S3::Bucket'
+  AWSIAMDynamoManagedPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Sid: DynamoGetBridgeData
+              Action:
+                - 'dynamodb:GetItem'
+                - 'dynamodb:Query'
+              Effect: Allow
+              Resource:
+                - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-HealthDataRecord3'
+                - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-HealthDataRecord3/index/uploadDate-index'
+                - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-HealthDataRecord3/index/study-uploadedOn-index'
+                - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-ParticipantOptions'
+                - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-Study'
+                - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-UploadSchema'
+            - Sid: DynamoGetPutExportTime
+              Action:
+                - 'dynamodb:GetItem'
+                - 'dynamodb:PutItem'
+              Effect: Allow
+              Resource:
+                - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-ExportTime'
+            - Sid: DynamoManageSynapseTables
+              Action:
+                - 'dynamodb:GetItem'
+                - 'dynamodb:PutItem'
+              Effect: Allow
+              Resource:
+                - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-exporter-testing-SynapseMetaTables'
+                - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-exporter-testing-SynapseTables'
+                - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-exporter-SynapseMetaTables'
+                - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-exporter-SynapseTables'
+            - Sid: DynamoPutAttachments
+              Action:
+                - 'dynamodb:PutItem'
+              Effect: Allow
+              Resource:
+                - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-HealthDataAttachment'
+            - Sid: DynamoScanStudyTable
+              Action:
+                - 'dynamodb:Scan'
+              Effect: Allow
+              Resource:
+                - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${BridgeEnv}-${BridgeUser}-Study'
+  AWSIAMS3ManagedPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            Action:
+              - 's3:PutObject'
+              - 's3:GetObject'
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:aws:s3:::${RecordIdsBucket}/*'
+              - Fn::ImportValue: !Sub "bridgepf-${BridgeEnv}-AttachmentBucket"
   AWSIAMServiceRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -271,6 +334,8 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/AWSElasticBeanstalkWorkerTier'
+        - !Ref AWSIAMDynamoManagedPolicy
+        - !Ref AWSIAMS3ManagedPolicy
   AWSIAMInstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
     Properties:
@@ -298,8 +363,9 @@ Resources:
     Type: 'AWS::IAM::Group'
     Properties:
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonSNSFullAccess
-        - arn:aws:iam::aws:policy/AmazonSQSFullAccess
+        - 'arn:aws:iam::aws:policy/AWSElasticBeanstalkWorkerTier'
+        - !Ref AWSIAMDynamoManagedPolicy
+        - !Ref AWSIAMS3ManagedPolicy
   AWSLBSecurityGroup:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
@@ -340,3 +406,7 @@ Outputs:
     Value: !Ref AWSS3AppDeployBucket
     Export:
       Name: !Sub '${AWS::StackName}-AppDeployBucket'
+  RecordIdsBucket:
+    Value: !Ref RecordIdsBucket
+    Export:
+      Name: !Sub '${AWS::StackName}-RecordIdsBucket'

--- a/env_vars
+++ b/env_vars
@@ -17,9 +17,13 @@ export BridgeWorkerEmail_uat=bridgeit+worker@sagebase.org
 export BridgeWorkerStudy_develop=api
 export BridgeWorkerStudy_prod=api
 export BridgeWorkerStudy_uat=api
+export RecordIdsBucket_develop=org-sagebridge-exporter-recordids-develop
+export RecordIdsBucket_prod=org-sagebridge-exporter-recordids-prod
+export RecordIdsBucket_uat=org-sagebridge-exporter-recordids-uat
 export SynapsePrincipalId_develop=3330889
 export SynapsePrincipalId_prod=3325672
 export SynapsePrincipalId_uat=3327942
 export SynapseUser_develop=BridgeExporterDev
 export SynapseUser_prod=BridgeExporter
 export SynapseUser_uat=BridgeExporterStaging
+

--- a/update_cf_stack.sh
+++ b/update_cf_stack.sh
@@ -7,6 +7,7 @@ eval export "BridgeWorkerEmail=\$BridgeWorkerEmail_$TRAVIS_BRANCH"
 eval export "BridgeWorkerStudy=\$BridgeWorkerStudy_$TRAVIS_BRANCH"
 eval export "BridgeWorkerPassword=\$BridgeWorkerPassword_$TRAVIS_BRANCH"
 eval export "Env=\$Env_$TRAVIS_BRANCH"
+eval export "RecordIdsBucket=\$RecordIdsBucket_$TRAVIS_BRANCH"
 eval export "SynapseApiKey=\$SynapseApiKey_$TRAVIS_BRANCH"
 eval export "SynapsePrincipalId=\$SynapsePrincipalId_$TRAVIS_BRANCH"
 eval export "SynapseUser=\$SynapseUser_$TRAVIS_BRANCH"
@@ -27,6 +28,7 @@ ParameterKey=BridgeWorkerStudy,ParameterValue=$BridgeWorkerStudy \
 ParameterKey=BridgeWorkerPassword,ParameterValue=$BridgeWorkerPassword \
 ParameterKey=EC2InstanceType,ParameterValue=t2.micro \
 ParameterKey=Env,ParameterValue=$Env \
+ParameterKey=RecordIdsBucket,ParameterValue=$RecordIdsBucket \
 ParameterKey=SynapseApiKey,ParameterValue=$SynapseApiKey \
 ParameterKey=SynapsePrincipalId,ParameterValue=$SynapsePrincipalId \
 ParameterKey=SynapseUser,ParameterValue=$SynapseUser


### PR DESCRIPTION
Add access policies to EB managed EC2 instances to allow the Bridge exporter
running on those EC2 machines to have access to AWS resources.