### PR TITLE
BRIDGE-1225: add health check metric and alarm

### DIFF
--- a/cf_templates/eb_app.yml
+++ b/cf_templates/eb_app.yml
@@ -552,6 +552,41 @@ Resources:
       Statistic: Sum
       Threshold: 100
       TreatMissingData: notBreaching
+  AWSCWHeartbeatMetricFilter:
+    Type: "AWS::Logs::MetricFilter"
+    DependsOn: AWSLogsTomcatLogGroup
+    Properties:
+      LogGroupName: !Join
+        - '/'
+        - - /aws/elasticbeanstalk
+          - !Ref 'AWS::StackName'
+          - var/log/tomcat8/catalina.out
+      FilterPattern: 'org.sagebionetworks.bridge.heartbeat.HeartbeatLogger'
+      MetricTransformations:
+        -
+          MetricValue: "1"
+          MetricNamespace: "LogMetrics/Health"
+          MetricName: !Join
+            - '-'
+            - - !Ref 'AWS::StackName'
+              - HeartbeatCount
+  AWSCWHealthCheckAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AWSSNSTopic
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Threshold: 0
+      EvaluationPeriods: 1
+      MetricName: !Join
+        - '-'
+        - - !Ref 'AWS::StackName'
+          - HeartbeatCount
+      Namespace: LogMetrics/Health
+      Period: 3600
+      Statistic: SampleCount
+      TreatMissingData: breaching
 Outputs:
   AWSSNSTopic:
     Value: !Ref AWSSNSTopic


### PR DESCRIPTION
Setup a health check notification based on the application heartbeat
messages.  Missing heartbeat messages is treated as a breach triggering
this alarm.