### PR TITLE
Suppress M2C2 from alarms

### DIFF
--- a/templates/bridge-exporter.yaml
+++ b/templates/bridge-exporter.yaml
@@ -557,7 +557,8 @@ Resources:
           - var/log/tomcat8/catalina.out
       FilterPattern: 'ERROR
                       - FileChunkUploadWorker
-                      - S3EventNotificationCallback'
+                      - S3EventNotificationCallback
+                      - psu-m2c2'
       MetricTransformations:
         -
           MetricValue: "1"


### PR DESCRIPTION
M2C2 is primarily a development project and is very noisy at generating alarms. This excludes that study ID from our alarms.