### PR TITLE
[IT-435] upgrade to use Sceptre ver 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,7 @@ git-crypt.key
 !.elasticbeanstalk/*.global.yml
 
 # sceptre artifacts
-remote-templates
+templates/remote
 
 # lambda artifacts
 lambdas/*.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: python
-python: 3.5
+python: 3.6
 cache: pip
 fast_finish: true
 branches:
@@ -9,11 +9,13 @@ branches:
   - uat
   - prod
 install:
-  - pip install cfn-lint
   - wget https://github.com/Sage-Bionetworks/infra-utils/archive/master.zip -O /tmp/infra-utils.zip
   - unzip -j -n /tmp/infra-utils.zip -x "infra-utils-master/.gitignore" "infra-utils-master/LICENSE" "infra-utils-master/*.md" "infra-utils-master/aws/*"
   - ./setup_aws_cli.sh || travis_terminate 1
-  - ./setup_sceptre.sh || travis_terminate 1
+  - pip install cfn-lint
+  - pip install git+git://github.com/zaro0508/sceptre@issue-586
+  - pip install git+git://github.com/zaro0508/sceptre-ssm-resolver.git
+  - pip install git+git://github.com/zaro0508/sceptre-date-resolver.git
 stages:
   - name: validate
   - name: deploy
@@ -21,8 +23,8 @@ stages:
 jobs:
   include:
     - stage: validate
-      script: cfn-lint ./templates/**/*.yaml
+      script: cfn-lint ./templates/**/*
     - stage: deploy
-      script:
-        - sceptre --var "profile=default" --var "region=us-east-1" launch-env $TRAVIS_BRANCH
+      script: sceptre launch $TRAVIS_BRANCH --yes
+
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,6 @@
+project_code: sage-bionetworks
+profile: {{ var.profile | default("default") }}
+region: {{ var.region | default("us-east-1") }}
+template_bucket_name: bootstrap-awss3cloudformationbucket-zov6lb1ge7ll
+template_key_prefix: {{ environment_variable.TRAVIS_BRANCH | default("testing") }}
+admincentral_cf_bucket: "bootstrap-awss3cloudformationbucket-19qromfd235z9"

--- a/config/develop/bridge-exporter.yaml
+++ b/config/develop/bridge-exporter.yaml
@@ -1,4 +1,4 @@
-template_path: templates/bridge-exporter.yaml
+template_path: bridge-exporter.yaml
 stack_name: bridge-exporter-develop
 parameters:
   AttachmentsBucket: org-sagebridge-attachment-develop

--- a/config/develop/config.yaml
+++ b/config/develop/config.yaml
@@ -1,5 +1,0 @@
-project_code: sage-bionetworks
-profile: {{ var.profile | default("default") }}
-region: {{ var.region }}
-template_bucket_name: bootstrap-awss3cloudformationbucket-zov6lb1ge7ll
-template_key_prefix: {{ environment_variable.TRAVIS_BRANCH | default("testing") }}

--- a/config/prod/bridge-exporter.yaml
+++ b/config/prod/bridge-exporter.yaml
@@ -1,4 +1,4 @@
-template_path: templates/bridge-exporter.yaml
+template_path: bridge-exporter.yaml
 stack_name: bridge-exporter-prod
 parameters:
   AttachmentsBucket: org-sagebridge-attachment-prod

--- a/config/prod/config.yaml
+++ b/config/prod/config.yaml
@@ -1,5 +1,0 @@
-project_code: sage-bionetworks
-profile: {{ var.profile | default("default") }}
-region: {{ var.region }}
-template_bucket_name: bootstrap-awss3cloudformationbucket-zov6lb1ge7ll
-template_key_prefix: {{ environment_variable.TRAVIS_BRANCH | default("testing") }}

--- a/config/uat/bridge-exporter.yaml
+++ b/config/uat/bridge-exporter.yaml
@@ -1,4 +1,4 @@
-template_path: templates/bridge-exporter.yaml
+template_path: bridge-exporter.yaml
 stack_name: bridge-exporter-uat
 parameters:
   AttachmentsBucket: org-sagebridge-attachment-uat

--- a/config/uat/config.yaml
+++ b/config/uat/config.yaml
@@ -1,5 +1,0 @@
-project_code: sage-bionetworks
-profile: {{ var.profile | default("default") }}
-region: {{ var.region }}
-template_bucket_name: bootstrap-awss3cloudformationbucket-zov6lb1ge7ll
-template_key_prefix: {{ environment_variable.TRAVIS_BRANCH | default("testing") }}


### PR DESCRIPTION
Upgrade from Sceptre 1.x to 2.x because V1 is end of life[1].
Followed the migration guide[2] to do the upgrade.

[1] cloudreach/sceptre#593
[2] https://github.com/cloudreach/sceptre/wiki/Migration-Guide:-V1-to-V2