### PR TITLE
suppress WarningHeaderInterceptor from warning alarm

### DIFF
--- a/templates/bridge-exporter.yaml
+++ b/templates/bridge-exporter.yaml
@@ -576,7 +576,7 @@ Resources:
         - - /aws/elasticbeanstalk
           - !Ref 'AWS::StackName'
           - var/log/tomcat8/catalina.out
-      FilterPattern: 'WARN'
+      FilterPattern: 'WARN - WarningHeaderInterceptor'
       MetricTransformations:
         -
           MetricValue: "1"


### PR DESCRIPTION
We updated JavaSDK, and now we're getting a bunch of warnings from WarningHeaderInterceptor. We don't care about these, since these are all related to the language header.